### PR TITLE
Fix import of dash_table (is not part of dash.dependencies anymore). …

### DIFF
--- a/RNODataViewer/file_list/file_list.py
+++ b/RNODataViewer/file_list/file_list.py
@@ -5,7 +5,8 @@ from RNODataViewer.base.app import app
 from dash import html
 from dash import dcc
 import pandas as pd
-from dash.dependencies import Input, Output, State, dash_table
+from dash.dependencies import Input, Output, State
+# import dash_table
 
 layout = html.Div([
     html.Div([

--- a/RNODataViewer/file_list/file_list.py
+++ b/RNODataViewer/file_list/file_list.py
@@ -6,7 +6,7 @@ from dash import html
 from dash import dcc
 import pandas as pd
 from dash.dependencies import Input, Output, State
-# import dash_table
+# from dash import dash_table
 
 layout = html.Div([
     html.Div([


### PR DESCRIPTION
…Comment module as it is not used

As of dash 2.0 dash_table is part of the main repo: https://pypi.org/project/dash-table/

In NuRadioMC we already require dash>=2. So we are good here
